### PR TITLE
Update freebsd.ipxe

### DIFF
--- a/src/freebsd.ipxe
+++ b/src/freebsd.ipxe
@@ -29,7 +29,7 @@ iseq ${ver} 11.2 && set image_subdir 11 ||
 iseq ${ver} 11.1 && set image_subdir 11 ||
 iseq ${ver} 11.0 && set image_subdir 11 ||
 iseq ${ver} 10.3 && set image_subdir 10/${freebsd_arch} ||
-set src http://mfsbsd.vx.sk/files/images/${image_subdir}/mfsbsd-${image_ver}-${freebsd_arch}.img
+set src http://mfsbsd.vx.sk/files/images/${image_subdir}/${freebsd_arch}/mfsbsd-${image_ver}-${freebsd_arch}.img
 imgfree
 echo This loads an mfsbsd installer (http://mfsbsd.vx.sk/).
 echo Root password for all images: mfsroot


### PR DESCRIPTION
The file for FreeBSD has the url for the mfsbsd image incorrect. There was an extra directory named after the architecture before the actual directory with the iso image.